### PR TITLE
Enhancement | Apply prettier to CSS and Improve pre-commit scripts

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -32,13 +32,7 @@ module.exports = {
         }
       ],
       // configure the prettier plugin
-      "prettier/prettier": [
-        "error",
-        {
-          trailingComma: "es5",
-          singleQuote: true
-        }
-      ]
+      "prettier/prettier": ["error"]
     },
     plugins: ["prettier"]
   };

--- a/client/.prettierrc.js
+++ b/client/.prettierrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  trailingComma: 'es5',
+  singleQuote: true,
+};

--- a/client/src/components/App/style.css
+++ b/client/src/components/App/style.css
@@ -1,5 +1,5 @@
 * {
-    padding: 0;
-    margin: 0;
-    box-sizing: border-box;
+  padding: 0;
+  margin: 0;
+  box-sizing: border-box;
 }

--- a/client/src/components/common/AvailabilityTime/style.css
+++ b/client/src/components/common/AvailabilityTime/style.css
@@ -4,10 +4,11 @@
 
 .Availabile_table {
   width: max-content;
-  border-radius: 1rem; 
+  border-radius: 1rem;
 }
 
-.ant-table td, .ant-table th{
+.ant-table td,
+.ant-table th {
   width: 6.7rem;
-  color: #32A48F
+  color: #32a48f;
 }

--- a/client/src/components/common/Card/style.css
+++ b/client/src/components/common/Card/style.css
@@ -1,65 +1,65 @@
 .card__photo {
-    border: 1px solid gray;
-    background-color:#82D9C9; 
-    width:100px;
+  border: 1px solid gray;
+  background-color: #82d9c9;
+  width: 100px;
 }
 
 .card__price {
-    font-family: Roboto, sans-serif;
-    font-style: normal;
-    font-weight: normal;
-    font-size: 12px;
-    line-height: 30px;
-    display: flex;
-    align-items: center;
-    color: #33000E;
+  font-family: Roboto, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  font-size: 12px;
+  line-height: 30px;
+  display: flex;
+  align-items: center;
+  color: #33000e;
 }
 
 .card__header {
-    font-family: Sansation, sans-serif;
-    font-style: normal;
-    font-weight: bold;
-    font-size: 18px;
-    line-height: 30px;
-    align-items: center;
-    color: #242424;
-    background: '#f7f7f7';
-    border-radius: 4px;
-    margin-bottom: 20px;
-    border: 0;
-    overflow: 'hidden';
+  font-family: Sansation, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+  font-size: 18px;
+  line-height: 30px;
+  align-items: center;
+  color: #242424;
+  background: '#f7f7f7';
+  border-radius: 4px;
+  margin-bottom: 20px;
+  border: 0;
+  overflow: 'hidden';
 }
 
 .card__content {
-    display: flex;
-    justify-content: space-around;
-    background-color: #E0E0E0;
+  display: flex;
+  justify-content: space-around;
+  background-color: #e0e0e0;
 }
 
-.card__approach, 
+.card__approach,
 .card__type {
-    font-family: Sansation, sans-serif;
-    font-style: normal;
-    font-weight: normal;
-    font-size: 16px;
-    line-height: 25px;
-    display: flex;
-    align-items: center;
-    color: #33000E;
+  font-family: Sansation, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  font-size: 16px;
+  line-height: 25px;
+  display: flex;
+  align-items: center;
+  color: #33000e;
 }
 
 .card__type {
-    font-size: 14px;
+  font-size: 14px;
 }
 
-.ant-collapse-item ,
+.ant-collapse-item,
 .ant-collapse-item-active,
- .card__header {
-    background-color: #C4C4C4 !important;
+.card__header {
+  background-color: #c4c4c4 !important;
 }
 
 .ant-collapse-header,
 .ant-collapse-content,
 .ant-collapse-content-active {
-    background-color: #E0E0E0 !important;
+  background-color: #e0e0e0 !important;
 }

--- a/client/src/components/common/Filter/style.css
+++ b/client/src/components/common/Filter/style.css
@@ -1,40 +1,40 @@
 .filter__submit-button {
-    margin-bottom: 10px;
-    text-align: center;
-    text-decoration: none;
-    border: none;
-    background-color: #32A48F;
-    border-radius: 3px;
-    letter-spacing: 1.5px;
-    font-weight: 600;
-    font-size: 18px;
-    font-family: Roboto;
-    cursor: pointer;
-    width: 100%;
-    height: 46px;
-    color: #fff;
+  margin-bottom: 10px;
+  text-align: center;
+  text-decoration: none;
+  border: none;
+  background-color: #32a48f;
+  border-radius: 3px;
+  letter-spacing: 1.5px;
+  font-weight: 600;
+  font-size: 18px;
+  font-family: Roboto;
+  cursor: pointer;
+  width: 100%;
+  height: 46px;
+  color: #fff;
 }
 
-.ant-form-item-children { 
-    width: 100%;
-    display: flex;
-    justify-content: center;
+.ant-form-item-children {
+  width: 100%;
+  display: flex;
+  justify-content: center;
 }
 
 .ant-switch-checked {
-    background-color: #32A48F !important;
+  background-color: #32a48f !important;
 }
 
 .ant-btn-primary {
-    background-color:#32A48F !important;    
+  background-color: #32a48f !important;
 }
 
 .label__swich-btn {
-    display: flex;
-    justify-content: space-between;
-    width:50%;
+  display: flex;
+  justify-content: space-between;
+  width: 50%;
 }
 
 .label__swich-btn {
-    display: flex !important;
+  display: flex !important;
 }

--- a/client/src/components/common/Header/style.css
+++ b/client/src/components/common/Header/style.css
@@ -1,109 +1,109 @@
 .header {
-    position: relative;
+  position: relative;
 }
 
 .header__bar {
-    background:#32A48F;
-    display: flex;
-    justify-content: space-between;
-    width: 100%;
-    height: 50px;
+  background: #32a48f;
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  height: 50px;
 }
 
 .header-logo {
-    display: flex;
-    justify-content: center;
+  display: flex;
+  justify-content: center;
 }
 
 .menu-icon {
-    background: none;
-    border: none;
-    outline: none;
-    text-align: center;
-    font-size: 20px;
-    padding: 10px 15px;
+  background: none;
+  border: none;
+  outline: none;
+  text-align: center;
+  font-size: 20px;
+  padding: 10px 15px;
 }
 
 .menu__model {
-    position: fixed;
-    left: 0;
-    top: 0;
-    width: 100%;
-    height: 100%;
-    background-color: rgba(143, 135, 135, 0.4);
-    transition: all 0.3s linear; 
-    z-index: 2;
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(143, 135, 135, 0.4);
+  transition: all 0.3s linear;
+  z-index: 2;
 }
 
 .menu__nav {
-    top:0;
-    position: absolute; 
-    transform: translateX(0);
-    visibility: visible;
-    transition: all 0.5s ease-in-out;
+  top: 0;
+  position: absolute;
+  transform: translateX(0);
+  visibility: visible;
+  transition: all 0.5s ease-in-out;
 }
 
 .menu__head {
-    background: #32A48F;
+  background: #32a48f;
 }
 
 .menu__title {
-    font-family: Sansation;
-    font-style: normal;
-    font-weight: bold;
-    font-size: 18px;
-    line-height: 30px;
-    display: flex;
-    align-items: center;
-    color: #FFFFFF;
-    margin: 0;
-    padding: 10px 15px;
+  font-family: Sansation;
+  font-style: normal;
+  font-weight: bold;
+  font-size: 18px;
+  line-height: 30px;
+  display: flex;
+  align-items: center;
+  color: #ffffff;
+  margin: 0;
+  padding: 10px 15px;
 }
 
 .menu__list {
-    padding: 0;
-    margin: 0;
-    background: #F3F3F3;
-    padding-left: 50px;
-    width: 70vw;
+  padding: 0;
+  margin: 0;
+  background: #f3f3f3;
+  padding-left: 50px;
+  width: 70vw;
 }
 
 .menu__item {
-    list-style: none;
-    display: flex;
-    align-items: center;
-    border-bottom: 1px solid #82D9C9;
-    height: 14vh;   
+  list-style: none;
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid #82d9c9;
+  height: 14vh;
 }
 
 .menu__link {
-    text-decoration: none;
-    padding: 10px 16px;
-    font-family: Sansation;
-    font-style: normal;
-    font-weight: bold;
-    font-size: 18px;
-    line-height: 30px;
-    display: flex;
-    align-items: center;
-    color: #242424;
-    cursor: pointer;
+  text-decoration: none;
+  padding: 10px 16px;
+  font-family: Sansation;
+  font-style: normal;
+  font-weight: bold;
+  font-size: 18px;
+  line-height: 30px;
+  display: flex;
+  align-items: center;
+  color: #242424;
+  cursor: pointer;
 }
 
 .menu_img {
-    padding: 0;
-    margin: 0;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    margin-left: -30px;
-    padding-top:25px; 
+  padding: 0;
+  margin: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-left: -30px;
+  padding-top: 25px;
 }
 
 .hide {
-    top:0;
-    position: absolute; 
-    transform: translateX(-100%);
-    visibility: hidden;
-    transition: all 0.5s ease-in-out;
+  top: 0;
+  position: absolute;
+  transform: translateX(-100%);
+  visibility: hidden;
+  transition: all 0.5s ease-in-out;
 }

--- a/client/src/components/common/Loader/style.css
+++ b/client/src/components/common/Loader/style.css
@@ -1,11 +1,11 @@
 .ant-spin-lg .ant-spin-dot i {
-    background-color: #32A48F;
+  background-color: #32a48f;
 }
 
 .ant-spin-spinning {
-    position: static;
-    opacity: 1;
-    display: flex;
-    justify-content: center;
-    align-items: center;
+  position: static;
+  opacity: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }

--- a/client/src/components/common/Location/style.css
+++ b/client/src/components/common/Location/style.css
@@ -1,5 +1,5 @@
 #map {
   margin: 0 auto;
   height: 40vh;
-  width: 20rem; 
+  width: 20rem;
 }

--- a/client/src/components/common/availabilityTable/style.css
+++ b/client/src/components/common/availabilityTable/style.css
@@ -1,34 +1,34 @@
 .table {
-    position: relative;
-    border-radius:20px; 
-    width: fit-content;
-    border: 0.5px solid gray;
+  position: relative;
+  border-radius: 20px;
+  width: fit-content;
+  border: 0.5px solid gray;
 }
 
 .table__day {
-    color: rgb(30, 31, 31);
+  color: rgb(30, 31, 31);
 }
 
 td {
-    display: flex;
-    padding: 0;
-    width: 33%;
-    flex-direction: column;
+  display: flex;
+  padding: 0;
+  width: 33%;
+  flex-direction: column;
 }
-  
+
 tr {
-    display: flex;
-    flex-direction: row;
-    border-top: none;
-    border-bottom:2px solid #82D9C9; 
+  display: flex;
+  flex-direction: row;
+  border-top: none;
+  border-bottom: 2px solid #82d9c9;
 }
 
 .ant-table table {
-    border-spacing: 5px;
+  border-spacing: 5px;
 }
 
 .ant-table-thead > tr > th {
-    background: #fff;
+  background: #fff;
 }
 
 th {
@@ -38,22 +38,25 @@ th {
 }
 
 .ant-table-pagination {
-    display: none;
+  display: none;
 }
 
-tbody > tr:last-child { 
-    border:none;
+tbody > tr:last-child {
+  border: none;
 }
 
-.ant-table-thead > tr > th, .ant-table-tbody > tr > td {
-    padding: 5px;
-    border:none;
+.ant-table-thead > tr > th,
+.ant-table-tbody > tr > td {
+  padding: 5px;
+  border: none;
 }
 
 tr > td:first-child {
-    width:80px;
+  width: 80px;
 }
 
-tr > td:last-child, th:last-child, thead > tr > th:last-child  {
-    padding-left: 30px; 
+tr > td:last-child,
+th:last-child,
+thead > tr > th:last-child {
+  padding-left: 30px;
 }

--- a/client/src/components/pages/About/style.css
+++ b/client/src/components/pages/About/style.css
@@ -3,13 +3,13 @@
 }
 
 .about-page__title {
-  color: #32A48F;
+  color: #32a48f;
   font-size: 30px;
   font-weight: bold;
 }
 
 .about-page__point {
-  color: #1C5C50;
+  color: #1c5c50;
   font-size: 16px;
 }
 

--- a/client/src/components/pages/Home/style.css
+++ b/client/src/components/pages/Home/style.css
@@ -1,83 +1,83 @@
 .home {
-    margin-top: 0px;
+  margin-top: 0px;
 }
 
 .home__header {
-    margin: 50px 20px 5px 20px;
-    display: inline-flex;
-    width: 90%;
+  margin: 50px 20px 5px 20px;
+  display: inline-flex;
+  width: 90%;
 }
 
 .home__box {
-    margin-top: 52px;
+  margin-top: 52px;
 }
 
 .home__title {
-    font-size: 36px;
-    font-weight: bold;
-    font-family: Roboto, sans-serif;
-    color: #32A48F;
-    line-height: 2px;
+  font-size: 36px;
+  font-weight: bold;
+  font-family: Roboto, sans-serif;
+  color: #32a48f;
+  line-height: 2px;
 }
 
 .home__subTitle {
-    font-size: 20px;
-    font-weight: bold;
-    font-family: Roboto, sans-serif;
-    color: #32A48F;
+  font-size: 20px;
+  font-weight: bold;
+  font-family: Roboto, sans-serif;
+  color: #32a48f;
 }
 
 .home__description {
-    font-size: 16px;
-    font-family: Roboto, sans-serif;
-    color: #1C7867;
-    margin: 0px 30px 30px 30px;
-    text-align: center;
+  font-size: 16px;
+  font-family: Roboto, sans-serif;
+  color: #1c7867;
+  margin: 0px 30px 30px 30px;
+  text-align: center;
 }
 
 .home_buttons {
-    margin-top: 130px;
-    margin-left: 5px ;
-    margin-right: 5px; 
+  margin-top: 130px;
+  margin-left: 5px;
+  margin-right: 5px;
 }
 
 .home__buttons__types-btn,
-.home__buttons__filter-btn{
-    margin-bottom: 10px;
-    text-align: center;
-    text-decoration: none;
-    border: none;
-    background-color: #32A48F;
-    border-radius: 3px;
-    letter-spacing: 1.5px;
-    font-weight: 600;
-    font-size: 18px;
-    font-family: Roboto, sans-serif;
-    cursor: pointer;
-    width: 100%;
-    height: 46px;
-    color: #fff;
+.home__buttons__filter-btn {
+  margin-bottom: 10px;
+  text-align: center;
+  text-decoration: none;
+  border: none;
+  background-color: #32a48f;
+  border-radius: 3px;
+  letter-spacing: 1.5px;
+  font-weight: 600;
+  font-size: 18px;
+  font-family: Roboto, sans-serif;
+  cursor: pointer;
+  width: 100%;
+  height: 46px;
+  color: #fff;
 }
 
 .home__buttons__types-icon {
-    margin-right: 5px;
+  margin-right: 5px;
 }
 
 .home__signup {
-    display: inline-flex;
-    margin-left: 95px;
+  display: inline-flex;
+  margin-left: 95px;
 }
 
 .home__signup__question {
-    text-align: center;
-    font-size: 18px;
-    font-family: Roboto, sans-serif;
-    margin-right: 10px;
+  text-align: center;
+  font-size: 18px;
+  font-family: Roboto, sans-serif;
+  margin-right: 10px;
 }
 
 .home__signup-link {
-    color: #45CBB2;
-    font-size: 18px;
-    font-weight: bold;
-    font-family: Roboto, sans-serif;
+  color: #45cbb2;
+  font-size: 18px;
+  font-weight: bold;
+  font-family: Roboto, sans-serif;
 }

--- a/client/src/components/pages/NotFound/style.css
+++ b/client/src/components/pages/NotFound/style.css
@@ -1,28 +1,28 @@
 .errorPage-img {
-    width: 300px;
-    height: 200px;
-    margin-top: 50px;
+  width: 300px;
+  height: 200px;
+  margin-top: 50px;
 }
 
 .errorPage-heading {
-    color: #32A48F;
-    font-size: 24px;
-    font-weight: bold;
+  color: #32a48f;
+  font-size: 24px;
+  font-weight: bold;
 }
 
 .errorPage-btn {
-    margin-bottom: 10px;
-    text-align: center;
-    text-decoration: none;
-    border: none;
-    background-color: #32A48F;
-    border-radius: 3px;
-    letter-spacing: 1.5px;
-    font-weight: 600;
-    font-size: 16px;
-    font-family: Roboto, sans-serif;
-    cursor: pointer;
-    width: 62%;
-    height: 46px;
-    color: #fff;
+  margin-bottom: 10px;
+  text-align: center;
+  text-decoration: none;
+  border: none;
+  background-color: #32a48f;
+  border-radius: 3px;
+  letter-spacing: 1.5px;
+  font-weight: 600;
+  font-size: 16px;
+  font-family: Roboto, sans-serif;
+  cursor: pointer;
+  width: 62%;
+  height: 46px;
+  color: #fff;
 }

--- a/client/src/components/pages/Profile/style.css
+++ b/client/src/components/pages/Profile/style.css
@@ -3,7 +3,7 @@
 }
 
 .profile_card_container {
-  background: #E0E0E0;
+  background: #e0e0e0;
   width: 375px;
   height: 265px;
   padding: 1rem 1rem 0 1rem;
@@ -19,7 +19,7 @@
 }
 
 .profile_avatar {
-  border: .3rem solid #32A48F;
+  border: 0.3rem solid #32a48f;
 }
 
 .profile_card {
@@ -44,22 +44,22 @@
 }
 
 .profile_card_fees {
-  background: #C4C4C4;
-  color: #33000E;
+  background: #c4c4c4;
+  color: #33000e;
   width: 345px;
   height: 3rem;
   display: block;
   margin: 1.5rem auto;
   padding: 1.1rem;
   text-align: center;
-  line-height: .2rem;
+  line-height: 0.2rem;
 }
 
 .profile_contact_container {
-  margin:1rem 0 0 2rem;
+  margin: 1rem 0 0 2rem;
 }
 
 .profile_contact_info {
-  color: #32A48F;
+  color: #32a48f;
   margin-left: 2rem;
 }

--- a/client/src/components/pages/QuestionaryPage/style.css
+++ b/client/src/components/pages/QuestionaryPage/style.css
@@ -1,74 +1,82 @@
 .questionary__container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
-
 
 .questionary__title {
-    font-family: Sansation;
-    font-style: normal;
-    font-weight: bold;
-    font-size: 30px;
-    line-height: 50px;
-    display: flex;
-    align-items: center;
-    text-align: center;
-    color: #32A48F;
+  font-family: Sansation;
+  font-style: normal;
+  font-weight: bold;
+  font-size: 30px;
+  line-height: 50px;
+  display: flex;
+  align-items: center;
+  text-align: center;
+  color: #32a48f;
 }
 
-@media (max-width: 480px){
-    .ant-steps-label-horizontal{
-        display: flex !important;
-        margin: 0;
-    }
-    .ant-steps-horizontal.ant-steps-label-horizontal > .ant-steps-item > .ant-steps-item-container > .ant-steps-item-tail {
-        display: none;
-        transform:rotate(90deg);
-    }
+@media (max-width: 480px) {
+  .ant-steps-label-horizontal {
+    display: flex !important;
+    margin: 0;
+  }
+  .ant-steps-horizontal.ant-steps-label-horizontal
+    > .ant-steps-item
+    > .ant-steps-item-container
+    > .ant-steps-item-tail {
+    display: none;
+    transform: rotate(90deg);
+  }
 
-.ant-steps-horizontal.ant-steps-label-horizontal > .ant-steps-item > .ant-steps-item-container > .ant-steps-item-tail {
-        top: -10px;
-        left: 0;
-    }
+  .ant-steps-horizontal.ant-steps-label-horizontal
+    > .ant-steps-item
+    > .ant-steps-item-container
+    > .ant-steps-item-tail {
+    top: -10px;
+    left: 0;
+  }
 }
 
 .ant-steps-item-container {
-    margin: 0 !important;
+  margin: 0 !important;
 }
 
 .ant-steps-item-icon {
-    width: 25px;
-    height: 25px;
-    line-height: 25px;
-    margin: 0 !important;
+  width: 25px;
+  height: 25px;
+  line-height: 25px;
+  margin: 0 !important;
 }
 
 .ant-radio-group {
-    display: flex;
-    flex-direction: column;
-    flex-wrap: wrap;
-    width: 80%;
-    height: 50vh;
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+  width: 80%;
+  height: 50vh;
 }
 
 .ant-steps-item-process .ant-steps-item-icon {
-    background: #32A48F;
-    border: none;
+  background: #32a48f;
+  border: none;
 }
 
-.ant-steps-item-finish > .ant-steps-item-container > .ant-steps-item-content > .ant-steps-item-title::after {
-    background: #32A48F
+.ant-steps-item-finish
+  > .ant-steps-item-container
+  > .ant-steps-item-content
+  > .ant-steps-item-title::after {
+  background: #32a48f;
 }
 
 .ant-radio-wrapper {
-    margin-bottom: 20px; 
-    margin-left: 20px;
+  margin-bottom: 20px;
+  margin-left: 20px;
 }
 
 .steps-content {
-    width : 80%;
-    display: flex;  
-    flex-direction: column;
-    padding-left:50px; 
+  width: 80%;
+  display: flex;
+  flex-direction: column;
+  padding-left: 50px;
 }

--- a/client/src/components/pages/Results/style.css
+++ b/client/src/components/pages/Results/style.css
@@ -1,34 +1,34 @@
 .Results {
-    margin: 40px 15px 15px 10px;
+  margin: 40px 15px 15px 10px;
 }
 
 .Results__TherapyType {
-    margin-bottom: 10px;
+  margin-bottom: 10px;
 }
 
-.Results__TherapyType__title { 
-    margin-top: 15px;
-    color: #242424;
-    font-size: 24px;
-    font-weight: bold;
-    font-family: Sansation, sans-serif;
+.Results__TherapyType__title {
+  margin-top: 15px;
+  color: #242424;
+  font-size: 24px;
+  font-weight: bold;
+  font-family: Sansation, sans-serif;
 }
 
 .Results__TherapyType__name {
-    color:#32A48F;
-    font-size: 18px;
-    font-weight: bold;
-    font-family: Sansation, sans-serif;
+  color: #32a48f;
+  font-size: 18px;
+  font-weight: bold;
+  font-family: Sansation, sans-serif;
 }
 
 .Results__TherapistsNames {
-    margin-top: 30px;
+  margin-top: 30px;
 }
 
 .Results__TherapistsNames__suggest {
-    color:#242424;
-    font-size: 18px;
-    font-weight: bold;
-    font-family: Sansation, sans-serif;
-    padding-bottom: 10px;
+  color: #242424;
+  font-size: 18px;
+  font-weight: bold;
+  font-family: Sansation, sans-serif;
+  padding-bottom: 10px;
 }

--- a/client/src/components/pages/Signup/style.css
+++ b/client/src/components/pages/Signup/style.css
@@ -1,9 +1,9 @@
 .signup-page {
-  margin: .5rem;
+  margin: 0.5rem;
 }
 
 .signup-page__title {
-  color: #32A48F;
+  color: #32a48f;
   font-size: 30px;
   font-weight: bold;
 }
@@ -15,7 +15,7 @@
 .signup-page__button {
   display: block;
   margin: 0 auto;
-  background-color: #32A48F;
+  background-color: #32a48f;
   width: 19rem;
   border-radius: 3px;
   letter-spacing: 1.5px;
@@ -43,12 +43,14 @@
   right: 6px;
 }
 
-.ant-table-row, tr {
+.ant-table-row,
+tr {
   width: 94%;
 }
 
-@media only screen and (min-width: 768px) { 
-tr > td, tr > th {
-  width:200px !important;
-}
+@media only screen and (min-width: 768px) {
+  tr > td,
+  tr > th {
+    width: 200px !important;
+  }
 }

--- a/client/src/components/pages/TherapyType/style.css
+++ b/client/src/components/pages/TherapyType/style.css
@@ -3,7 +3,7 @@
 }
 
 .types-page__title {
-  color: #32A48F;
+  color: #32a48f;
   font-size: 30px;
   font-weight: bold;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,16 +32,80 @@
         "regenerator-runtime": "^0.13.2"
       }
     },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+      "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.3",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+      "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+      "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.3",
+        "fastq": "^1.6.0"
+      }
+    },
+    "@samverschueren/stream-to-observable": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
+      "integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
+      "dev": true,
+      "requires": {
+        "any-observable": "^0.3.0"
+      }
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
       "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
       "dev": true
     },
+    "@types/events": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+      "dev": true
+    },
+    "@types/glob": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+      "dev": true,
+      "requires": {
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
       "integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
+      "dev": true
+    },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "12.12.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.5.tgz",
+      "integrity": "sha512-KEjODidV4XYUlJBF3XdjSH5FWoMCtO0utnhtdLf1AgeuZLOrRbvmU/gaRCVg7ZaQDjVf3l84egiY0mRNe5xE4A==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
@@ -119,6 +183,16 @@
       "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
       "dev": true
     },
+    "aggregate-error": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
+      "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+      "dev": true,
+      "requires": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      }
+    },
     "airtable": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/airtable/-/airtable-0.7.1.tgz",
@@ -175,6 +249,12 @@
       "requires": {
         "color-convert": "^1.9.0"
       }
+    },
+    "any-observable": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
+      "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
+      "dev": true
     },
     "anymatch": {
       "version": "2.0.0",
@@ -252,6 +332,12 @@
         "define-properties": "^1.1.2",
         "es-abstract": "^1.7.0"
       }
+    },
+    "array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true
     },
     "array-unique": {
       "version": "0.3.2",
@@ -518,6 +604,32 @@
         "unset-value": "^1.0.0"
       }
     },
+    "caller-callsite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
+      "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
+      "dev": true,
+      "requires": {
+        "callsites": "^2.0.0"
+      },
+      "dependencies": {
+        "callsites": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+          "dev": true
+        }
+      }
+    },
+    "caller-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
+      "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
+      "dev": true,
+      "requires": {
+        "caller-callsite": "^2.0.0"
+      }
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -635,6 +747,12 @@
         }
       }
     },
+    "clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true
+    },
     "cli-boxes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
@@ -648,6 +766,59 @@
       "dev": true,
       "requires": {
         "restore-cursor": "^2.0.0"
+      }
+    },
+    "cli-truncate": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
+      "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+      "dev": true,
+      "requires": {
+        "slice-ansi": "0.0.4",
+        "string-width": "^1.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "slice-ansi": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+          "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
       }
     },
     "cli-width": {
@@ -702,6 +873,12 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
     },
     "component-emitter": {
       "version": "1.3.0",
@@ -832,6 +1009,46 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cosmiconfig": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+      "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+      "dev": true,
+      "requires": {
+        "import-fresh": "^2.0.0",
+        "is-directory": "^0.3.1",
+        "js-yaml": "^3.13.1",
+        "parse-json": "^4.0.0"
+      },
+      "dependencies": {
+        "import-fresh": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+          "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+          "dev": true,
+          "requires": {
+            "caller-path": "^2.0.0",
+            "resolve-from": "^3.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "resolve-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+          "dev": true
+        }
+      }
+    },
     "create-error-class": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
@@ -876,6 +1093,12 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "date-fns": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
+      "dev": true
+    },
     "debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -889,6 +1112,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
+    },
+    "dedent": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
     },
     "deep-equal": {
@@ -963,6 +1192,39 @@
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
       "dev": true
     },
+    "del": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-5.1.0.tgz",
+      "integrity": "sha512-wH9xOVHnczo9jN2IW68BabcecVPxacIA3g/7z6vhSU/4stOKQzeCRK0yD0A24WiAAUJmmVpWqrERcTxnLo3AnA==",
+      "dev": true,
+      "requires": {
+        "globby": "^10.0.1",
+        "graceful-fs": "^4.2.2",
+        "is-glob": "^4.0.1",
+        "is-path-cwd": "^2.2.0",
+        "is-path-inside": "^3.0.1",
+        "p-map": "^3.0.0",
+        "rimraf": "^3.0.0",
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "is-path-inside": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
+          "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.0.tgz",
+          "integrity": "sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -987,6 +1249,23 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
+    },
+    "dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "requires": {
+        "path-type": "^4.0.0"
+      },
+      "dependencies": {
+        "path-type": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+          "dev": true
+        }
+      }
     },
     "doctrine": {
       "version": "3.0.0",
@@ -1050,6 +1329,12 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
+    "elegant-spinner": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
+      "dev": true
+    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
@@ -1060,6 +1345,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
     },
     "error-ex": {
       "version": "1.3.2",
@@ -1620,6 +1914,64 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
+    "fast-glob": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.0.tgz",
+      "integrity": "sha512-TrUz3THiq2Vy3bjfQUB2wNyPdGBeGmdjbzzBLhfHN4YFurYptCKwGq/TfiRavbGywFRzY6U2CdmQ1zmsY5yYaw==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.0",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.2"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
+      }
+    },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -1630,6 +1982,15 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fastq": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.6.0.tgz",
+      "integrity": "sha512-jmxqQ3Z/nXoeyDmWAzF9kH1aGZSis6e/SbfPmJpUnyZ0ogr6iscHQaml4wsEepEWSdtmpy+eVXmCRIMpxaXqOA==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.0"
+      }
     },
     "fd-slicer": {
       "version": "1.1.0",
@@ -2425,6 +2786,12 @@
         }
       }
     },
+    "get-own-enumerable-property-symbols": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.1.tgz",
+      "integrity": "sha512-09/VS4iek66Dh2bctjRkowueRJbY1JDGR1L/zRxO1Qk8Uxs6PnqaNSqalpizPT+CDjre3hnEsuzvhgomz9qYrA==",
+      "dev": true
+    },
     "get-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
@@ -2490,6 +2857,30 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
+    },
+    "globby": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.1.tgz",
+      "integrity": "sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==",
+      "dev": true,
+      "requires": {
+        "@types/glob": "^7.1.1",
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.0.3",
+        "glob": "^7.1.3",
+        "ignore": "^5.1.1",
+        "merge2": "^1.2.3",
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+          "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+          "dev": true
+        }
+      }
     },
     "got": {
       "version": "6.7.1",
@@ -2687,6 +3078,12 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -2831,6 +3228,12 @@
         }
       }
     },
+    "is-directory": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+      "dev": true
+    },
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -2913,6 +3316,21 @@
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
+    "is-observable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
+      "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "^1.1.0"
+      }
+    },
+    "is-path-cwd": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+      "dev": true
+    },
     "is-path-inside": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
@@ -2950,6 +3368,12 @@
       "requires": {
         "has": "^1.0.1"
       }
+    },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+      "dev": true
     },
     "is-retry-allowed": {
       "version": "1.2.0",
@@ -3024,6 +3448,12 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
     },
     "json-schema": {
       "version": "0.2.3",
@@ -3143,6 +3573,301 @@
         "type-check": "~0.3.2"
       }
     },
+    "lint-staged": {
+      "version": "10.0.0-1",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-10.0.0-1.tgz",
+      "integrity": "sha512-9aGMF56huVzVksN/sFiP9VLBJY78QbZ1F+CxItH2kMBQq+8aa7OCiux0qUtzhG3vqC3m+fBSzVzyj1gxrHnmHA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2",
+        "commander": "^2.20.0",
+        "cosmiconfig": "^5.2.1",
+        "debug": "^4.1.1",
+        "dedent": "^0.7.0",
+        "del": "^5.0.0",
+        "execa": "^2.0.3",
+        "listr": "^0.14.3",
+        "log-symbols": "^3.0.0",
+        "micromatch": "^4.0.2",
+        "normalize-path": "^3.0.0",
+        "please-upgrade-node": "^3.1.1",
+        "stringify-object": "^3.3.0"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "cross-spawn": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
+          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "execa": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-2.1.0.tgz",
+          "integrity": "sha512-Y/URAVapfbYy2Xp/gb6A0E7iR8xeqOCXsuuaoMn7A5PzrXUK84E1gyiEfq0wQd/GHA6GsoHWwhNq8anb0mleIw==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^3.0.0",
+            "onetime": "^5.1.0",
+            "p-finally": "^2.0.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "get-stream": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
+          "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "onetime": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
+        },
+        "p-finally": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+          "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
+          "dev": true
+        },
+        "path-key": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
+          "integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        },
+        "which": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.1.tgz",
+          "integrity": "sha512-N7GBZOTswtB9lkQBZA4+zAXrjEIWAUOB93AvzUiudRzRxhUdLURQ7D/gAIMY1gatT/LTbmbcv8SiYazy3eYB7w==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "listr": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/listr/-/listr-0.14.3.tgz",
+      "integrity": "sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==",
+      "dev": true,
+      "requires": {
+        "@samverschueren/stream-to-observable": "^0.3.0",
+        "is-observable": "^1.1.0",
+        "is-promise": "^2.1.0",
+        "is-stream": "^1.1.0",
+        "listr-silent-renderer": "^1.1.1",
+        "listr-update-renderer": "^0.5.0",
+        "listr-verbose-renderer": "^0.5.0",
+        "p-map": "^2.0.0",
+        "rxjs": "^6.3.3"
+      },
+      "dependencies": {
+        "p-map": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+          "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+          "dev": true
+        }
+      }
+    },
+    "listr-silent-renderer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+      "dev": true
+    },
+    "listr-update-renderer": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
+      "integrity": "sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "cli-truncate": "^0.2.1",
+        "elegant-spinner": "^1.0.1",
+        "figures": "^1.7.0",
+        "indent-string": "^3.0.0",
+        "log-symbols": "^1.0.2",
+        "log-update": "^2.3.0",
+        "strip-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
+          }
+        },
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
+          "requires": {
+            "chalk": "^1.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "listr-verbose-renderer": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
+      "integrity": "sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.1",
+        "cli-cursor": "^2.1.0",
+        "date-fns": "^1.27.2",
+        "figures": "^2.0.0"
+      }
+    },
     "load-json-file": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
@@ -3210,6 +3935,26 @@
       "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
       "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
       "dev": true
+    },
+    "log-symbols": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2"
+      }
+    },
+    "log-update": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
+      "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.0.0",
+        "cli-cursor": "^2.0.0",
+        "wrap-ansi": "^3.0.1"
+      }
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -3285,6 +4030,18 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
+    "merge2": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
+      "integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
+      "dev": true
     },
     "methods": {
       "version": "1.1.2",
@@ -3824,6 +4581,15 @@
         "p-limit": "^1.1.0"
       }
     },
+    "p-map": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+      "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+      "dev": true,
+      "requires": {
+        "aggregate-error": "^3.0.0"
+      }
+    },
     "p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
@@ -3953,6 +4719,12 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
+    "picomatch": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.1.0.tgz",
+      "integrity": "sha512-uhnEDzAbrcJ8R3g2fANnSuXZMBtkpSjxTTgn2LeSiQlfmq72enQJWdQllXW24MBLYnA1SBD2vfvx2o0Zw3Ielw==",
+      "dev": true
+    },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -3966,6 +4738,15 @@
       "dev": true,
       "requires": {
         "find-up": "^2.1.0"
+      }
+    },
+    "please-upgrade-node": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
+      "integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
+      "dev": true,
+      "requires": {
+        "semver-compare": "^1.0.0"
       }
     },
     "plur": {
@@ -4093,6 +4874,16 @@
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.7.tgz",
       "integrity": "sha512-xsMgrUwRpuGskEzBFkH8NmTimbZ5PcPup0LA8JJkHIm2IMUbQcpo3yeLNWVrufEYjh8YwtSVh0xz6UeWc5Oh5A==",
       "dev": true
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "punycode": {
       "version": "2.1.1",
@@ -4359,6 +5150,12 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true
+    },
     "rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -4375,6 +5172,12 @@
       "requires": {
         "is-promise": "^2.1.0"
       }
+    },
+    "run-parallel": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+      "dev": true
     },
     "rxjs": {
       "version": "6.5.3",
@@ -4413,6 +5216,12 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true
+    },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
       "dev": true
     },
     "semver-diff": {
@@ -4537,6 +5346,12 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true
     },
     "slice-ansi": {
       "version": "2.1.0",
@@ -4859,6 +5674,17 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "stringify-object": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
+      "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
+      "dev": true,
+      "requires": {
+        "get-own-enumerable-property-symbols": "^3.0.0",
+        "is-obj": "^1.0.1",
+        "is-regexp": "^1.0.0"
+      }
+    },
     "strip-ansi": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -4886,6 +5712,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
+    "strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "dev": true
     },
     "strip-json-comments": {
@@ -4941,6 +5773,12 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+      "dev": true
     },
     "synchronous-promise": {
       "version": "2.0.10",
@@ -5574,6 +6412,27 @@
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
+    },
+    "wrap-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
+      "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
+      "dev": true,
+      "requires": {
+        "string-width": "^2.1.1",
+        "strip-ansi": "^4.0.0"
+      },
+      "dependencies": {
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "description": "## **Team Members** * Abdallah Ammar (Team Lead) * Hashem Taha  * Fadi Omar  * Mohammad Alhallaq * Asmaa Thabet",
   "scripts": {
     "test": "NODE_ENV=test node test | tap-spec",
-    "lint": "eslint server",
-    "lint:react": "cd client/ && npm run lint",
+    "lint": "lint-staged",
     "start": "NODE_ENV=production node ./server",
     "dev": "NODE_ENV=development nodemon ./server",
     "heroku-postbuild": "cd client && npm i && npm run build"
@@ -29,6 +28,7 @@
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-react": "^7.16.0",
+    "lint-staged": "^10.0.0-1",
     "nodemon": "^1.19.2",
     "pre-commit": "^1.2.2",
     "supertest": "^4.0.2",
@@ -47,8 +47,18 @@
     "typescript": "^3.6.4",
     "yup": "^0.27.0"
   },
+  "lint-staged": {
+    "./client/**/*.{js,jsx,ts,tsx,json,css,scss,md}": [
+      "client/node_modules/.bin/prettier --write"
+    ],
+    "./client/**/*.{js,jsx,ts,tsx,json}": [
+      "client/node_modules/.bin/eslint --fix"
+    ],
+    "./server/**/*.{js,jsx,ts,tsx,json}": [
+      "eslint --fix"
+    ]
+  },
   "pre-commit": [
-    "lint:react",
     "lint",
     "test"
   ],


### PR DESCRIPTION
## Overview

This PR includes changes related to `prettier`, and adds features to the pre-commit logic.

Personal aside: *Since I'm just joining the team, I want to acknowledge my limited awareness of the project context. I hope none of these changes add complications for people, or are at odds with pre-existing consensus -- and I appreciate y'all's consideration!*


## Changes

### 1. Prettier + CSS
I noticed that some of the CSS files had minor formatting issues here and there. One neat thing about `prettier` is that it supports a good amount of languages other than JS, including CSS. So I ran `prettier` to auto-format the CSS. [[CSS formatting commit](https://github.com/GSG-G7/shrinc/pull/128/commits/7fe5b44d6f3a8480c07d74d7cffe6521765626cf)]

I wanted to make sure I was referencing the client's `prettier` config, which I was defined in `.eslintrc.js`. In order to support running `prettier` independently from `eslint`, I extracted the prettier-related config to a standalone `.prettierrc.js`, leaving the eslint-specific error definition.

### 2. Pre-commit Lint
In case not everyone has "format on save" enabled in their IDE, I thought it'd be handy to add a pre-commit script that auto-formats with `prettier`. 

When I started to look into adding a `prettier` lint, I noticed an opportunity to optimize the pre-commit process so that it only runs lint scripts against files that have been staged for commit in git, using a tool called `lint-staged`.

I updated the pre-commit config to use `lint-staged` for the lint scripts and adapted the lint scripts to use the `lint-staged` config. 

I made sure that the eslint was running for both server and client, using their respective eslint configs.

### Considerations for Team Feedback

* I took the liberty of removing the npm scripts that applied to the client app, from the root (server) package.json, since they duplicated the new `lint-staged` configuration. But please let me know if that's a bad assumption.

* Prettier formats the CSS with a couple conventions that are different than existing conventions, specifically: a) changed indent from 4 space to 2; b) changed hex colors from caps to lowercase, for letters. Easy enough to [fix](https://stackoverflow.com/a/54757106) if it's a bother -- let me know

* I only tested on my mac, and I know that windows can sometimes work a little differently so it might be worth testing on windows to make sure things are groovy for both OSes.


Thanks!!
